### PR TITLE
fix: use correct token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TOKEN_TO_TRIGGER_SUBSEQUENT_WORKFLOWS  }}
           NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |


### PR DESCRIPTION
Normal token does not trigger other workflows.

We want to run `.github/workflows/semantic-tags-after-release.yml` after a release. 