### PR TITLE
fix: `oxlint` fails the pre-commit hook when every staged file is ignored

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     },
     "lint-staged": {
         "*.{ts,tsx}": [
-            "oxlint --",
+            "oxlint --no-error-on-unmatched-pattern --",
             "depcruise --config dependency-cruiser.config.ts --include-only ^src/ --validate --"
         ],
         "*": [


### PR DESCRIPTION
oxlint applies `ignorePatterns` to explicit paths and exits 1 when none remain.